### PR TITLE
Add InsecureTLS support for internal Kubernetes services

### DIFF
--- a/document-service/cmd/seed.go
+++ b/document-service/cmd/seed.go
@@ -246,6 +246,7 @@ func runSeed(cmd *cobra.Command, args []string) error {
 			BucketPort:      cfg.Storage.BucketPort,
 			BucketName:      cfg.Storage.BucketName,
 			UseSSL:          cfg.Storage.UseSSL,
+			InsecureTLS:     cfg.Storage.InsecureTLS,
 			Region:          cfg.Storage.Region,
 			AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
 			SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),

--- a/document-service/cmd/serve.go
+++ b/document-service/cmd/serve.go
@@ -158,6 +158,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			BucketPort:      cfg.Storage.BucketPort,
 			BucketName:      cfg.Storage.BucketName,
 			UseSSL:          cfg.Storage.UseSSL,
+			InsecureTLS:     cfg.Storage.InsecureTLS,
 			Region:          cfg.Storage.Region,
 			AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
 			SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),


### PR DESCRIPTION
## Summary

Fix TLS certificate verification errors when connecting to NooBaa S3 endpoint in OpenShift.

## Problem

NooBaa on OpenShift uses HTTPS with an internal CA certificate that isn't trusted by the Go runtime:

```
x509: certificate signed by unknown authority
```

## Solution

- Add `InsecureTLS` field to StorageConfig and S3Config
- Auto-enable InsecureTLS for `*.svc` hostnames (internal Kubernetes services)
- Allow explicit override via `BUCKET_INSECURE_TLS` environment variable
- Configure S3 client with custom HTTP transport when InsecureTLS is set

## Auto-detection logic

| BUCKET_HOST | InsecureTLS |
|-------------|-------------|
| `s3.openshift-storage.svc` | `true` (auto) |
| `localhost` | `false` |
| `minio.example.com` | `false` |

Can be overridden with `BUCKET_INSECURE_TLS=true` or `BUCKET_INSECURE_TLS=false`.

## Test plan

- [ ] Document-service starts successfully on OpenShift with ODF/NooBaa
- [ ] Init container seeds documents correctly
- [ ] Local MinIO testing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)